### PR TITLE
fix(database): set proper permissions on my.cnf to enable UTF-8 encoding

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,6 @@
+FROM mysql:latest
+
+COPY my.cnf /etc/mysql/conf.d/my.cnf
+RUN chmod 644 /etc/mysql/conf.d/my.cnf
+
+COPY init.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
 
   database:
-    image: mysql:latest
+    build: ./database
     container_name: mysql-dev
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -44,10 +44,7 @@ services:
       MYSQL_PASSWORD: password
       TZ: Asia/Tokyo
     ports:
-        - 3306:3306
-    volumes:
-      - ./database:/docker-entrypoint-initdb.d
-      - ./database/my.cnf:/etc/mysql/conf.d/my.cnf
+      - 3306:3306
     healthcheck:
       test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "user", "-p${MYSQL_PASSWORD}" ]
       interval: 5s


### PR DESCRIPTION
- Add Dockerfile for database service to set my.cnf permissions to 644
- Update docker-compose.yml to build database from Dockerfile
- Resolves "World-writable config file is ignored" warning
- Ensures UTF-8mb4 character set is properly loaded