### PR TITLE
feat: add resizable notes section below seat grid

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -48,14 +48,14 @@ let connection: any;
 
     app.get('/api/columns/:dashboardId', async (req, res) => {
         const [rows]: any = await connection.execute('SELECT * FROM dashboard_settings WHERE id = ?', [req.params.dashboardId]);
-        res.json(rows[0] || { team_label: 'Team', name_label: 'Name', note1_label: 'Note 1', note2_label: 'Note 2', split_position: 40 });
+        res.json(rows[0] || { team_label: 'Team', name_label: 'Name', note1_label: 'Note 1', note2_label: 'Note 2', grid_width: 40, grid_height: 70, notes: '' });
     });
 
     app.put('/api/columns/:dashboardId', async (req, res) => {
-        const { team_label, name_label, note1_label, note2_label, split_position } = req.body;
+        const { team_label, name_label, note1_label, note2_label, grid_width, grid_height, notes } = req.body;
         await connection.execute(
-            'INSERT INTO dashboard_settings (id, team_label, name_label, note1_label, note2_label, split_position) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE team_label=?, name_label=?, note1_label=?, note2_label=?, split_position=?',
-            [req.params.dashboardId, team_label, name_label, note1_label, note2_label, split_position, team_label, name_label, note1_label, note2_label, split_position]
+            'INSERT INTO dashboard_settings (id, team_label, name_label, note1_label, note2_label, grid_width, grid_height, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE team_label=?, name_label=?, note1_label=?, note2_label=?, grid_width=?, grid_height=?, notes=?',
+            [req.params.dashboardId, team_label, name_label, note1_label, note2_label, grid_width, grid_height, notes, team_label, name_label, note1_label, note2_label, grid_width, grid_height, notes]
         );
         res.json({ success: true });
     });

--- a/database/init.sql
+++ b/database/init.sql
@@ -5,7 +5,9 @@ CREATE TABLE IF NOT EXISTS dashboard_settings (
     name_label VARCHAR(50) CHARACTER SET utf8 DEFAULT 'Name',
     note1_label VARCHAR(50) CHARACTER SET utf8 DEFAULT 'Note 1',
     note2_label VARCHAR(50) CHARACTER SET utf8 DEFAULT 'Note 2',
-    split_position INT DEFAULT 40
+    grid_width INT DEFAULT 40,
+    grid_height INT DEFAULT 70,
+    notes TEXT CHARACTER SET utf8
 );
 
 CREATE TABLE IF NOT EXISTS user (


### PR DESCRIPTION
- Add notes field to dashboard_settings table with grid_width and grid_height columns
- Implement vertical resizer between seat grid and notes section
- Persist notes content and layout dimensions per dashboard
- Rename split_position to grid_width and grid_split_position to grid_height for clarity
- Notes section saves automatically on blur
- Both resizers only active in edit mode