### PR TITLE
feat: add environment variable support for database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database Configuration
+DB_ROOT_PASSWORD=root
+DB_NAME=database-dev
+DB_USER=user
+DB_PASSWORD=password
+DB_HOST=database
+
+# Timezone
+TZ=Asia/Tokyo

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - 5173:5173
     environment:
-      TZ: Asia/Tokyo
+      TZ: ${TZ}
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -20,7 +20,11 @@ services:
     ports:
       - 3000:3000
     environment:
-      TZ: Asia/Tokyo
+      TZ: ${TZ}
+      DB_HOST: ${DB_HOST}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
     volumes:
       - ./backend:/app
       - /app/node_modules
@@ -38,15 +42,15 @@ services:
     build: ./database
     container_name: mysql-dev
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: database-dev
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
-      TZ: Asia/Tokyo
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: ${TZ}
     ports:
       - 3306:3306
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "user", "-p${MYSQL_PASSWORD}" ]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${DB_USER}", "-p${DB_PASSWORD}" ]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
- Add .env.example template file with database configuration
- Update docker-compose.yml to use environment variables
- Unify database variable naming to DB_* convention
- Add .env to .gitignore to prevent credential exposure